### PR TITLE
changed links icons to text #22

### DIFF
--- a/resumegenerator.html
+++ b/resumegenerator.html
@@ -283,20 +283,16 @@
                                     <!-- <div class="linkedin p-0">
                                         <img src="images/linkedin.png" class="rounded mx-0.5 d-block p-0" style="width: 20px;" id="gitT">
                                     </div> -->
+
+                                    <!-- changed icons to text  -->
                                     <div class="git p-0">
-                                        <a id="githubLink" href="#">
-                                            <img src="images/git.png" class="rounded mx-0.5 d-block p-0"
-                                                style="width: 20px; margin-right: 2px;">
-                                        </a>
+                                        <a id="githubLink" href="#" class="text-black no-underline hover:text-gray-500">Github</a>
                                     </div>
-
-                                    <div class="linkedin p-0">
-                                        <a id="linkedinLink" href="#">
-                                            <img src="images/linkedin.png" class="rounded mx-0.5 d-block p-0"
-                                                style="width: 20px;">
-                                        </a>
-                                    </div>
-
+                                        <span class="mx-2">|</span>
+                                    <div class="linkedin p-0">  
+                                        <a id="linkedinLink" href="#" class="text-black no-underline hover:text-gray-500">Linkedin</a>
+                                    </div>  
+                                
                                 </div>
                             </div>
 


### PR DESCRIPTION
**Title:** Changed link icons to text

Fixes #22

#### Brief description of what is fixed or changed
I replaced the link icons with text for the GitHub and LinkedIn links. The links now appear as "Github | LinkedIn" in black, without the default underline, using Tailwind CSS. This resolves the issue of displaying unwanted icons or bullets before the links.

#### Other comments
No other major changes were made, just styling improvements to align with the requested format.
