### PR TITLE
removed icons and changed it to Text #22

### DIFF
--- a/resumegenerator.html
+++ b/resumegenerator.html
@@ -292,6 +292,11 @@
                                     <div class="linkedin p-0">  
                                         <a id="linkedinLink" href="#" class="text-black no-underline hover:text-gray-500">Linkedin</a>
                                     </div>  
+                                    <span class="mx-2">|</span>
+
+                                    <div class="website p-0">  
+                                        <a id="websiteLink" href="#" class="text-black no-underline hover:text-gray-500">Linkedin</a>
+                                    </div>  
                                 
                                 </div>
                             </div>

--- a/resumegenerator.html
+++ b/resumegenerator.html
@@ -69,14 +69,19 @@
                                 <label for="" class="fw-bold my-2">LinkedIn</label>
                                 <input type="text" placeholder="Paste your LinkedIn account link"
                                     class="form-control my-2" id="linkedinF">
-
+                                    
+                                    <label for="" class="fw-bold my-2">Website</label>
+                                    <input type="text" placeholder="Paste your website link" class="form-control my-2"
+                                        id="websiteF">
                                 <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
                                 <script>
                                     $(document).ready(function () {
                                         const gitInput = $("#gitF");
                                         const linkedinInput = $("#linkedinF");
+                                        const websiteInput = $("#websiteF"); 
                                         const githubLink = $("#githubLink");
                                         const linkedinLink = $("#linkedinLink");
+                                        const websiteLink = $("#websiteLink");
 
                                         gitInput.on("input", function () {
                                             const githubUrl = gitInput.val();
@@ -87,12 +92,14 @@
                                             const linkedinUrl = linkedinInput.val();
                                             linkedinLink.attr("href", linkedinUrl);
                                         });
+
+                                        websiteInput.on("input", function () {
+                                            const websiteUrl = websiteInput.val();
+                                            websiteLink.attr("href", websiteUrl);
+                                        });
                                     });
                                 </script>
 
-                                <label for="" class="fw-bold my-2">Website</label>
-                                <input type="text" placeholder="Paste your website link" class="form-control my-2"
-                                    id="websiteF">
 
 
                                 <h3>Academic Details</h3>
@@ -294,7 +301,7 @@
                                     </div>
                                     <span class="mx-2">|</span>
                                     <div class="website p-0">  
-                                        <a id="websiteLink" href="#" class="text-black no-underline hover:text-gray-500">Linkedin</a>
+                                        <a id="websiteLink" href="#" class="text-black no-underline hover:text-gray-500">website</a>
                                     </div>  
                                 
                                 </div>

--- a/resumegenerator.html
+++ b/resumegenerator.html
@@ -293,7 +293,6 @@
                                         <a id="linkedinLink" href="#" class="text-black no-underline hover:text-gray-500">Linkedin</a>
                                     </div>  
                                     <span class="mx-2">|</span>
-
                                     <div class="website p-0">  
                                         <a id="websiteLink" href="#" class="text-black no-underline hover:text-gray-500">Linkedin</a>
                                     </div>  

--- a/resumegenerator.html
+++ b/resumegenerator.html
@@ -283,20 +283,16 @@
                                     <!-- <div class="linkedin p-0">
                                         <img src="images/linkedin.png" class="rounded mx-0.5 d-block p-0" style="width: 20px;" id="gitT">
                                     </div> -->
+
+                                    <!-- changed icons to text  -->
                                     <div class="git p-0">
-                                        <a id="githubLink" href="#">
-                                            <img src="images/git.png" class="rounded mx-0.5 d-block p-0"
-                                                style="width: 20px; margin-right: 2px;">
-                                        </a>
+                                        <a id="githubLink" href="#" class="text-black no-underline hover:text-gray-500">Github</a>
                                     </div>
-
-                                    <div class="linkedin p-0">
-                                        <a id="linkedinLink" href="#">
-                                            <img src="images/linkedin.png" class="rounded mx-0.5 d-block p-0"
-                                                style="width: 20px;">
-                                        </a>
-                                    </div>
-
+                                        <span class="mx-2">|</span>
+                                    <div class="linkedin p-0">  
+                                        <a id="linkedinLink" href="#" class="text-black no-underline hover:text-gray-500">Linkedin</a>
+                                    </div>  
+                                
                                 </div>
                             </div>
 

--- a/resumegenerator.html
+++ b/resumegenerator.html
@@ -301,7 +301,7 @@
                                     </div>
                                     <span class="mx-2">|</span>
                                     <div class="website p-0">  
-                                        <a id="websiteLink" href="#" class="text-black no-underline hover:text-gray-500">website</a>
+                                        <a id="websiteLink" href="#" class="text-black no-underline hover:text-gray-500">Website</a>
                                     </div>  
                                 
                                 </div>

--- a/resumegenerator.html
+++ b/resumegenerator.html
@@ -285,13 +285,13 @@
                                     </div> -->
 
                                     <!-- changed icons to text  -->
+                                    <div class="linkedin p-0">  
+                                        <a id="linkedinLink" href="#" class="text-black no-underline hover:text-gray-500">Linkedin</a>
+                                    </div> 
+                                    <span class="mx-2">|</span>
                                     <div class="git p-0">
                                         <a id="githubLink" href="#" class="text-black no-underline hover:text-gray-500">Github</a>
                                     </div>
-                                        <span class="mx-2">|</span>
-                                    <div class="linkedin p-0">  
-                                        <a id="linkedinLink" href="#" class="text-black no-underline hover:text-gray-500">Linkedin</a>
-                                    </div>  
                                     <span class="mx-2">|</span>
                                     <div class="website p-0">  
                                         <a id="websiteLink" href="#" class="text-black no-underline hover:text-gray-500">Linkedin</a>


### PR DESCRIPTION
**Title:** Changed link icons to text

Fixes #22

#### Brief description of what is fixed or changed
I replaced the link icons with text for the GitHub and LinkedIn links. The links now appear as "Github | LinkedIn | website" in black, without the default underline, using Tailwind CSS. This resolves the issue of displaying unwanted icons or bullets before the links.

#### Other comments
No other major changes were made, just styling improvements to align with the requested format.
